### PR TITLE
create intermediate shadowRoot to scope styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ that styling of the overlay can be done like this:
 ### Styling the content
 
 Content can be styled by passing a `<style>` element into the template.
-Styles will be scoped by creating an intermediate `shadowRoot` to host
-the content.
+Styles will be scoped by creating an intermediate element and hosting
+the content in its `shadowRoot`. 
 
 ```html
 <iron-overlay>
@@ -133,6 +133,32 @@ the content.
     <div class="my-content">Other Content</div>
   </template>
 </iron-overlay>
+```
+
+⚠️ This will make your content "invisible" to query selectors and won't allow non-composed events to bubble ⚠️ ️
+
+Use `overlay.contentHost` to access to the element hosting your content.
+
+```html
+<iron-overlay id="overlay" opened>
+  <template>
+    <style>
+      my-content {
+        background-color: yellow;
+      }
+    </style>
+    <my-content class="my-content">Content</my-content>
+  </template>
+</iron-overlay>
+
+<script>
+  overlay.renderer.querySelector('my-content'); // null
+  overlay.contentHost.querySelector('my-content'); // <my-content>
+
+  // Imagine <my-content> fires 'my-content-ready' event, bubbling and non-composed
+  overlay.renderer.addEventListener('my-content-ready', doStuff); // callback never invoked
+  overlay.contentHost.addEventListener('my-content-ready', doStuff);
+</script>
 ```
 
 The best approach to ensure style encapsulation is to create a custom element

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ that styling of the overlay can be done like this:
 
 ### Styling the content
 
-Content can be styled by passing a `<style>` element into the template,
-but beware of possible conflicts with classes, as selectors will apply to all
-matching elements in the styling context where they're hosted:
+Content can be styled by passing a `<style>` element into the template.
+Styles will be scoped by creating an intermediate `shadowRoot` to host
+the content.
 
 ```html
 <iron-overlay>
@@ -129,7 +129,7 @@ matching elements in the styling context where they're hosted:
 
 <iron-overlay>
   <template>
-    <!-- Will have yellow background as well -->
+    <!-- Will not have yellow background -->
     <div class="my-content">Other Content</div>
   </template>
 </iron-overlay>

--- a/README.md
+++ b/README.md
@@ -106,53 +106,50 @@ be placed in a stacking-context safe node (e.g. `document.body`).
 
 ## Styling
 
-Styling must be done in the context of where iron-overlay-renderer will be hosted.
-
-### Styling the content
-
-Content can be styled by passing a `<style>` element into the template.
+You can style the content by passing a `<style>` element into the template.
 
 ```html
 <iron-overlay>
   <template>
     <style>
-      .my-content {
-        background-color: yellow;
-      }
+      div { background-color: yellow; }
     </style>
-    <div class="my-content">Content</div>
+    <div>Warning</div>
   </template>
 </iron-overlay>
 
 <iron-overlay>
   <template>
-    <!-- Will not have yellow background -->
-    <div class="my-content">Other Content</div>
+    <style>
+      div { background-color: red; }
+    </style>
+    <div>Error</div>
   </template>
 </iron-overlay>
 ```
 
-### Styling the renderer
-
-`iron-overlay` sets the renderer's `data-overlay` attribute to be its id, so
+Additionally, `iron-overlay` sets the renderer's `data-overlay` attribute to be its `id`, so
 that styling of the overlay can be done like this:
 
 ```html
 <custom-style><style is="custom-style">
-  [data-overlay] {  
+  iron-overlay-container [data-overlay] {  
     --iron-overlay-background-color: yellow;
   }
-  [data-overlay="overlay1"] {
-    --iron-overlay-background-color: orange;
+  iron-overlay-container [data-overlay="overlay1"] {
+    --iron-overlay-background-color: red;
   }
 </style></custom-style>
 
 <div style="transform: translateZ(0);">
   <iron-overlay>
-    <template>Yellow overlay</template>
+    <template>Warning</template>
   </iron-overlay>
   <iron-overlay id="overlay1">
-    <template>Orange overlay</template>
+    <template>Error</template>
   </iron-overlay>
 </div>
+
+<!-- it will contain all the overlay renderers -->
+<iron-overlay-container></iron-overlay-container>
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ events `iron-overlay-attach` and `iron-overlay-detach`, or append it to `<body>`
 It requires overlay contents to be contained in a `<template>` (since they need
 to be hosted in the renderer).
 
+Template content will be scoped by creating an intermediate element and hosting
+the content in its `shadowRoot`. 
+
+⚠️ This will make your content "invisible" to query selectors and won't allow non-composed events to bubble ⚠️ ️
+
+Use `overlay.contentHost` to access to the element hosting your content.
+
+```html
+<iron-overlay id="overlay" opened>
+  <template>
+    <my-content>Content</my-content>
+  </template>
+</iron-overlay>
+
+<script>
+  overlay.renderer.querySelector('my-content'); // null
+  overlay.contentHost.querySelector('my-content'); // <my-content>
+
+  // Imagine <my-content> fires 'my-content-ready' event, bubbling and non-composed
+  overlay.renderer.addEventListener('my-content-ready', doStuff); // callback never invoked
+  overlay.contentHost.addEventListener('my-content-ready', doStuff);
+</script>
+```
+
 ## iron-overlay-renderer
 
 Takes care of the rendering (e.g. center overlay), and handles the switch from
@@ -82,38 +106,11 @@ be placed in a stacking-context safe node (e.g. `document.body`).
 
 ## Styling
 
-Styling must be done in the context of where iron-overlay will be hosted.
-
-### Styling the renderer
-
-`iron-overlay` sets the renderer's `data-overlay` attribute to be its id, so
-that styling of the overlay can be done like this:
-
-```html
-<custom-style><style is="custom-style">
-  [data-overlay] {  
-    --iron-overlay-background-color: yellow;
-  }
-  [data-overlay="overlay1"] {
-    --iron-overlay-background-color: orange;
-  }
-</style></custom-style>
-
-<div style="transform: translateZ(0);">
-  <iron-overlay>
-    <template>Overlay Content</template>
-  </iron-overlay>
-  <iron-overlay id="overlay1">
-    <template>Overlay 1 Content</template>
-  </iron-overlay>
-</div>
-```
+Styling must be done in the context of where iron-overlay-renderer will be hosted.
 
 ### Styling the content
 
 Content can be styled by passing a `<style>` element into the template.
-Styles will be scoped by creating an intermediate element and hosting
-the content in its `shadowRoot`. 
 
 ```html
 <iron-overlay>
@@ -135,45 +132,27 @@ the content in its `shadowRoot`.
 </iron-overlay>
 ```
 
-⚠️ This will make your content "invisible" to query selectors and won't allow non-composed events to bubble ⚠️ ️
+### Styling the renderer
 
-Use `overlay.contentHost` to access to the element hosting your content.
-
-```html
-<iron-overlay id="overlay" opened>
-  <template>
-    <style>
-      my-content {
-        background-color: yellow;
-      }
-    </style>
-    <my-content class="my-content">Content</my-content>
-  </template>
-</iron-overlay>
-
-<script>
-  overlay.renderer.querySelector('my-content'); // null
-  overlay.contentHost.querySelector('my-content'); // <my-content>
-
-  // Imagine <my-content> fires 'my-content-ready' event, bubbling and non-composed
-  overlay.renderer.addEventListener('my-content-ready', doStuff); // callback never invoked
-  overlay.contentHost.addEventListener('my-content-ready', doStuff);
-</script>
-```
-
-The best approach to ensure style encapsulation is to create a custom element
-for your content.
+`iron-overlay` sets the renderer's `data-overlay` attribute to be its id, so
+that styling of the overlay can be done like this:
 
 ```html
-<iron-overlay>
-  <template>
-    <my-content>Content</my-content>
-  </template>
-</iron-overlay>
+<custom-style><style is="custom-style">
+  [data-overlay] {  
+    --iron-overlay-background-color: yellow;
+  }
+  [data-overlay="overlay1"] {
+    --iron-overlay-background-color: orange;
+  }
+</style></custom-style>
 
-<iron-overlay>
-  <template>
-    <my-other-content>Other Content</my-other-content>
-  </template>
-</iron-overlay>
+<div style="transform: translateZ(0);">
+  <iron-overlay>
+    <template>Yellow overlay</template>
+  </iron-overlay>
+  <iron-overlay id="overlay1">
+    <template>Orange overlay</template>
+  </iron-overlay>
+</div>
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -58,6 +58,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </template>
         <iron-overlay id="plain2">
           <template>
+            <style>
+              h2 { color: red;}
+            </style>
             <h2>Plain 2</h2>
             <button onclick="plain2.opened = false">Close</button>
           </template>

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <custom-style><style is="custom-style" include="demo-pages-shared-styles">
     demo-snippet {
       --demo-snippet-code: {
-        max-height: 250px;
+        padding: 0 5px;
       }
     }
     demo-snippet.no-demo {
@@ -141,7 +141,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <demo-snippet class="no-demo">
     <template>
       <custom-style><style is="custom-style">
-        [data-overlay] {
+        iron-overlay-container > * {
           --iron-overlay: {
             border: 1px solid gray;
             padding: 10px;
@@ -156,7 +156,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           };
         }
       </style></custom-style>
-      <iron-overlay-container overlay-type="iron-overlay"></iron-overlay-container>
+      <iron-overlay-container></iron-overlay-container>
     </template>
   </demo-snippet>
 

--- a/demo/x-menu-button-renderer.html
+++ b/demo/x-menu-button-renderer.html
@@ -62,6 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         ready() {
+          super.ready();
           document.addEventListener('scroll', () => this._position(), {
             passive: true
           });

--- a/demo/x-menu-button-renderer.html
+++ b/demo/x-menu-button-renderer.html
@@ -11,23 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-overlay-renderer.html">
 
 <dom-module id="x-menu-button-renderer">
-  <template strip-whitespace>
-    <style include="iron-overlay-renderer-shared-styles">
-      #overlay {
-        position: absolute;
-        transform: translateY(20px);
-        transition: opacity .2s, transform .2s;
-      }
-      
-      #overlay.opened {
-        transform: translateY(0);
-      }
-    </style>
-    <div id="overlay">
-      <slot></slot>
-    </div>
-  </template>
-
   <script>
     (() => {
       'use strict';
@@ -36,6 +19,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         static get is() {
           return 'x-menu-button-renderer';
+        }
+
+        static get template() {
+          const template = super.template;
+          const style = document.createElement('style');
+          style.textContent =
+            `#overlay {
+  position: absolute;
+  transform: translateY(20px);
+  transition: opacity .2s, transform .2s;
+}
+#overlay.opened {
+  transform: translateY(0);
+}`;
+          template.content.appendChild(style);
+          return template;
         }
 
         static get properties() {
@@ -69,10 +68,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         _renderOpenedChanged() {
-          super._renderOpenedChanged();
           this._positionRAF && window.cancelAnimationFrame(this._positionRAF);
           this._positionRAF = null;
           this.position();
+          super._renderOpenedChanged();
         }
 
         position() {

--- a/demo/x-menu-button.html
+++ b/demo/x-menu-button.html
@@ -28,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         on-iron-select="_close">
       </x-menu-button-renderer>
     </template>
-    <div on-click="open" id="trigger">
+    <div on-click="_open" id="trigger">
       <slot name="trigger"></slot>
     </div>
     <slot></slot>
@@ -64,6 +64,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               }
             }
           };
+        }
+
+        _open() {
+          this.opened = true;
         }
 
         _close() {

--- a/iron-overlay-container.html
+++ b/iron-overlay-container.html
@@ -55,7 +55,7 @@ Use `overlayType` to limit which types of overlays this container should host:
         super();
         // List of overlays handled by this container.
         this._overlays = [];
-        this._host = null;
+        this._rootNode = null;
         // Bind these methods to `this` as they are used for event listeners.
         this._onAttach = this._onAttach.bind(this);
         this._onDetach = this._onDetach.bind(this);
@@ -64,14 +64,14 @@ Use `overlayType` to limit which types of overlays this container should host:
       connectedCallback() {
         super.connectedCallback();
         // Listeners on the host.
-        this._host = this._getHostRoot();
-        this._host.addEventListener('iron-overlay-attach', this._onAttach);
+        this._rootNode = this.getRootNode();
+        this._rootNode.addEventListener('iron-overlay-attach', this._onAttach);
       }
 
       disconnectedCallback() {
         super.disconnectedCallback();
-        this._host.removeEventListener('iron-overlay-attach', this._onAttach);
-        this._host = null;
+        this._rootNode.removeEventListener('iron-overlay-attach', this._onAttach);
+        this._rootNode = null;
       }
 
       /**
@@ -151,21 +151,6 @@ Use `overlayType` to limit which types of overlays this container should host:
           event.preventDefault();
           event.stopPropagation();
         }
-      }
-
-      /**
-       * Returns the root element hosting the container.
-       * @returns {Node}
-       */
-      _getHostRoot() {
-        let n = this;
-        while (n) {
-          if (n.nodeType === Node.DOCUMENT_FRAGMENT_NODE && n.host) {
-            return n;
-          }
-          n = n.parentNode;
-        }
-        return document;
       }
     }
 

--- a/iron-overlay-container.html
+++ b/iron-overlay-container.html
@@ -133,7 +133,7 @@ Use `overlayType` to limit which types of overlays this container should host:
           return;
         }
 
-        if (this.attachOverlay(event.target)) {
+        if (this.attachOverlay(event.composedPath()[0])) {
           event.preventDefault();
           event.stopPropagation();
         }

--- a/iron-overlay-renderer-shared-styles.html
+++ b/iron-overlay-renderer-shared-styles.html
@@ -37,17 +37,9 @@ Custom property | Description | Default
         right: 0;
         bottom: 0;
         /* Center content horizontally & vertically */
-        display: -ms-flexbox;
-        display: -webkit-flex;
         display: flex;
-        -ms-flex-direction: column;
-        -webkit-flex-direction: column;
         flex-direction: column;
-        -ms-flex-align: center;
-        -webkit-align-items: center;
         align-items: center;
-        -ms-flex-pack: center;
-        -webkit-justify-content: center;
         justify-content: center;
 
         z-index: 101;

--- a/iron-overlay-renderer.html
+++ b/iron-overlay-renderer.html
@@ -171,9 +171,14 @@ styling can be done like this:
             this._forceLayout();
           }
           // Update classes for overlay and backdrop.
-          this.$.overlay.classList.toggle('opened', this.opened);
+          // NOTE: IE doesn't support 2nd arg for `classList.toggle()`.
+          this.$.overlay.classList.remove('opened');
           // Check if there is a backdrop in the shadow dom.
-          this.$.backdrop && this.$.backdrop.classList.toggle('opened', this.opened);
+          this.$.backdrop && this.$.backdrop.classList.remove('opened');
+          if (this.opened) {
+            this.$.overlay.classList.add('opened');
+            this.$.backdrop && this.$.backdrop.classList.add('opened');
+          }
           this._renderOpenedChanged();
         }
 

--- a/iron-overlay-renderer.html
+++ b/iron-overlay-renderer.html
@@ -109,28 +109,15 @@ styling can be done like this:
         }
 
         ready() {
-          super.ready();
-          // If delegatesFocus is not supported or class is extended but doesn't
-          // have a shadow root, make the element focusable but not tabbable.
-          if (!this.shadowRoot || !this.shadowRoot.delegatesFocus) {
+          this.attachShadow({
+            mode: 'open',
+            delegatesFocus: true
+          });
+          // If delegatesFocus is not supported, fallback to tabindex.
+          if (!this.shadowRoot.delegatesFocus) {
             this.setAttribute('tabindex', '-1');
           }
-        }
-
-        /**
-         * Overridden from Polymer.Element to ensure the shadow root delegates focus.
-         * See Polymer/polymer#3988
-         * @protected
-         */
-        _attachDom(dom) {
-          // Create shadowRoot only when there is content to be added
-          if (dom && this.attachShadow && !this.shadowRoot) {
-            this.attachShadow({
-              mode: 'open',
-              delegatesFocus: true
-            });
-          }
-          return super._attachDom(dom);
+          super.ready();
         }
 
         /**

--- a/iron-overlay-renderer.html
+++ b/iron-overlay-renderer.html
@@ -45,7 +45,7 @@ styling can be done like this:
   <template strip-whitespace>
     <style include="iron-overlay-renderer-shared-styles"></style>
     <div id="backdrop"></div>
-    <div id="overlay">
+    <div id="overlay" on-transitionend="_onTransitionEnd">
       <slot></slot>
     </div>
   </template>
@@ -115,7 +115,6 @@ styling can be done like this:
           if (!this.shadowRoot || !this.shadowRoot.delegatesFocus) {
             this.setAttribute('tabindex', '-1');
           }
-          this.$.overlay.addEventListener('transitionend', this._onTransitionEnd.bind(this));
         }
 
         /**

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -366,8 +366,17 @@ styling can be done like this:
                 this.__contentInstance && this.__contentInstance.forwardHostProp(prop, value);
               }
             }))();
-            // Append children to renderer.
-            renderer.appendChild(this.__contentInstance.root);
+            // Scope styles by creating an intermediate shadowRoot.
+            if (this.__contentInstance.root.querySelector('style')) {
+              const el = document.createElement('div');
+              el.attachShadow({
+                mode: 'open' //TODO(valdrin) consider mode: 'closed'
+              }).appendChild(this.__contentInstance.root);
+              renderer.appendChild(el);
+            } else {
+              // Append children to renderer.
+              renderer.appendChild(this.__contentInstance.root);
+            }
           }
           return renderer;
         }
@@ -492,7 +501,7 @@ styling can be done like this:
             // Consider <body> as null.
             if (active === document.body) {
               active = null;
-            } 
+            }
             while (active && active.shadowRoot && active.shadowRoot.activeElement) {
               active = active.shadowRoot.activeElement;
             }

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -162,7 +162,7 @@ styling can be done like this:
       }
 
       const sharedListener = new SharedEventListener();
-      const contentHostGenerator = new ScopingHostGenerator('content-host');
+      const contentHostGenerator = new ScopingHostGenerator('iron-overlay-content-host');
 
       class IronOverlay extends Polymer.Element {
 

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -464,27 +464,24 @@ styling can be done like this:
           }
         }
 
-        _onTransitioningChanged(event) {
-          const transitioning = event.detail.value;
-          if (transitioning) {
+        _onTransitioningChanged() {
+          if (this.renderer.transitioning) {
             this._toggleListeners();
             this.applyFocus();
+          } else if (this.opened) {
+            this.dispatchEvent(new CustomEvent('iron-overlay-opened', {
+              cancelable: false,
+              bubbles: true,
+              composed: true
+            }));
           } else {
-            if (this.opened) {
-              this.dispatchEvent(new CustomEvent('iron-overlay-opened', {
-                cancelable: false,
-                bubbles: true,
-                composed: true
-              }));
-            } else {
-              this.dispatchEvent(new CustomEvent('iron-overlay-closed', {
-                cancelable: false,
-                bubbles: true,
-                composed: true,
-                detail: this.closingReason
-              }));
-              this._ensureDetached();
-            }
+            this.dispatchEvent(new CustomEvent('iron-overlay-closed', {
+              cancelable: false,
+              bubbles: true,
+              composed: true,
+              detail: this.closingReason
+            }));
+            this._ensureDetached();
           }
         }
 

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -171,8 +171,8 @@ styling can be done like this:
             },
 
             /**
-             * The host of the content.
-             * @type {Element|DocumentFragment}
+             * The shadowRoot of the content host.
+             * @type {DocumentFragment}
              */
             contentHost: {
               type: Node,
@@ -187,7 +187,7 @@ styling can be done like this:
              * @protected
              */
             _restoreFocusNode: {
-              type: Object,
+              type: Node,
               value: null
             },
 

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -87,7 +87,8 @@ styling can be done like this:
     (() => {
       'use strict';
 
-      const contentHostGenerator = new Polymer.ScopingHostGenerator('iron-overlay-content-host');
+      const _contentHostGenerator = new ScopingHostGenerator('iron-overlay-content-host');
+      const _sharedListener = new SharedEventListener();
 
       class IronOverlay extends Polymer.Element {
 
@@ -184,19 +185,6 @@ styling can be done like this:
             _restoreFocusNode: {
               type: Object,
               value: null
-            },
-
-            /**
-             * A shared event listener to handle interactions like click or keydown.
-             * The last overlay opened will be the last to listen for events, but should
-             * be the first to handle the event. The shared event listener allows this, delegating
-             * the handling of the event to the last one listening for it.
-             * @protected
-             */
-            _sharedListener: {
-              type: Object,
-              readOnly: true,
-              value: new Polymer.SharedEventListener()
             }
           };
         }
@@ -272,7 +260,7 @@ styling can be done like this:
             cancelable: true,
             bubbles: true,
             composed: true,
-            detail : event
+            detail: event
           });
           this.dispatchEvent(cancelEvent);
           if (!cancelEvent.defaultPrevented) {
@@ -288,11 +276,11 @@ styling can be done like this:
          */
         _toggleListeners() {
           if (this.opened) {
-            this._sharedListener.listen('click', this, '_captureOutsideClick');
-            this._sharedListener.listen('keydown', this, '_captureEscapeKey');
+            _sharedListener.listen('click', this, '_captureOutsideClick');
+            _sharedListener.listen('keydown', this, '_captureEscapeKey');
           } else {
-            this._sharedListener.unlisten('click', this);
-            this._sharedListener.unlisten('keydown', this);
+            _sharedListener.unlisten('click', this);
+            _sharedListener.unlisten('keydown', this);
           }
         }
 
@@ -318,7 +306,7 @@ styling can be done like this:
           if (contentTemplate) {
             // Scope styles by creating an intermediate element's shadowRoot.
             if (contentTemplate.content.querySelector('style')) {
-              const el = contentHostGenerator.generate(contentTemplate);
+              const el = _contentHostGenerator.generate(contentTemplate);
               renderer.appendChild(el);
               this._setContentHost(el.shadowRoot);
             } else {
@@ -484,7 +472,7 @@ styling can be done like this:
                 cancelable: false,
                 bubbles: true,
                 composed: true,
-                detail : this.closingReason
+                detail: this.closingReason
               }));
               this._ensureDetached();
             }

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -175,7 +175,7 @@ styling can be done like this:
              * @type {Element|DocumentFragment}
              */
             contentHost: {
-              type: Object,
+              type: Node,
               readOnly: true
             },
 
@@ -405,6 +405,9 @@ styling can be done like this:
          * Ensures the renderer is attached.
          */
         _ensureAttached() {
+          if (!this.isConnected) {
+            return;
+          }
           this._ensureInstance();
           if (this.renderer.isConnected) {
             return;
@@ -453,7 +456,7 @@ styling can be done like this:
               active = active.shadowRoot.activeElement;
             }
             this._restoreFocusNode = active;
-            this.isConnected && this._ensureAttached();
+            this._ensureAttached();
           }
           // If renderer is already transitioning, it means the previous transition
           // didn't complete yet, e.g. close before open animation is completed.

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -240,6 +240,14 @@ styling can be done like this:
               readOnly: true
             },
 
+            /**
+             * The host of the content.
+             */
+            contentHost: {
+              type: Element,
+              readOnly: true
+            },
+
             _restoreFocusNode: {
               type: Node,
               value: null
@@ -383,9 +391,9 @@ styling can be done like this:
             if (contentTemplate.content.querySelector('style')) {
               const el = contentHostGenerator.generate(contentTemplate);
               renderer.appendChild(el);
-              this._contentHost = el.shadowRoot;
+              this._setContentHost(el.shadowRoot);
             } else {
-              this._contentHost = renderer;
+              this._setContentHost(renderer);
             }
             this.__contentInstance = new(Polymer.Templatize.templatize(contentTemplate, this, {
               forwardHostProp(prop, value) {
@@ -393,7 +401,7 @@ styling can be done like this:
               }
             }))();
             // Append children to renderer.
-            this._contentHost.appendChild(this.__contentInstance.root);
+            this.contentHost.appendChild(this.__contentInstance.root);
           }
           return renderer;
         }

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -12,6 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/lib/utils/gestures.html">
 <link rel="import" href="../polymer/lib/utils/templatize.html">
 <link rel="import" href="iron-overlay-renderer.html">
+<link rel="import" href="shared-event-listener.html">
+<link rel="import" href="scoping-host-generator.html">
 
 <!--
 `iron-overlay` is an element that can be hidden or shown, and displays on top of other content.
@@ -86,83 +88,8 @@ styling can be done like this:
     (() => {
       'use strict';
 
-      /**
-       * SharedEventListener allows to register callback for an event on document
-       * ensuring that the last registered callback is the one called.
-       * e.g. `node1`, `node2`, then `node3` listen for `click` event -> `node3`
-       * is the one to handle it.
-       */
-      class SharedEventListener {
-
-        constructor() {
-          this._events = {};
-          this._handleEvent = this._handleEvent.bind(this);
-          // Enable document-wide gesture recognizer.
-          Polymer.Gestures.addListener(document, 'tap', null);
-        }
-        /**
-         * Expects a callback that returns true when it handles the event, false
-         * to allow the event to be handled by the next listener.
-         */
-        listen(eventName, listener, callback) {
-          if (!this._events[eventName]) {
-            this._events[eventName] = [];
-            document.addEventListener(eventName, this._handleEvent, {
-              capture: true
-            });
-          }
-          // It's fine if we have duplicates, as the last one counts.
-          this._events[eventName].push({
-            listener: listener,
-            callback: callback
-          });
-        }
-
-        unlisten(eventName, listener) {
-          if (!this._events[eventName]) {
-            return;
-          }
-          // Remove all matching listeners.
-          const listeners = this._events[eventName].filter(obj => obj.listener !== listener);
-          if (listeners.length) {
-            this._events[eventName] = listeners;
-          } else {
-            this._events[eventName] = null;
-            document.removeEventListener(eventName, this._handleEvent, {
-              capture: true
-            });
-          }
-        }
-
-        _handleEvent(event) {
-          const handlers = this._events[event.type];
-          let i = handlers.length - 1;
-          let handler = null;
-          while ((handler = handlers[i--]) && !handler.listener[handler.callback](event)) {
-            // Keep looping until someone handles the event.
-          }
-        }
-      }
-
-      class ScopingHostGenerator {
-        constructor(hostNamePrefix) {
-          this._count = 0;
-          this._prefix = hostNamePrefix;
-        }
-        generate(template) {
-          const hostName = this._prefix + '-' + this._count++;
-          window.ShadyCSS && ShadyCSS.prepareTemplate(template, hostName);
-          const el = document.createElement(hostName);
-          el.attachShadow({
-            mode: 'open'
-          });
-          window.ShadyCSS && ShadyCSS.styleElement(el);
-          return el;
-        }
-      }
-
-      const sharedListener = new SharedEventListener();
-      const contentHostGenerator = new ScopingHostGenerator('iron-overlay-content-host');
+      const sharedListener = new Polymer.SharedEventListener();
+      const contentHostGenerator = new Polymer.ScopingHostGenerator('iron-overlay-content-host');
 
       class IronOverlay extends Polymer.Element {
 

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -192,10 +192,15 @@ styling can be done like this:
             }
           };
         }
+        connectedCallback() {
+          super.connectedCallback();
+          this.opened && this._ensureAttached();
+        }
 
         disconnectedCallback() {
           super.disconnectedCallback();
-          this._ensureDetached();
+          // Force closing.
+          this.opened = false;
         }
 
         /**
@@ -414,9 +419,6 @@ styling can be done like this:
         }
 
         _openedChanged(opened) {
-          if (!this.isConnected) {
-            return;
-          }
           // Reset the closing reason to false.
           this.closingReason.canceled = false;
           if (opened) {
@@ -430,13 +432,13 @@ styling can be done like this:
               active = active.shadowRoot.activeElement;
             }
             this._restoreFocusNode = active;
-            this._ensureAttached();
+            this.isConnected && this._ensureAttached();
           }
           // If renderer is already transitioning, it means the previous transition
           // didn't complete yet, e.g. close before open animation is completed.
           // We need to update here the listeners and move focus, as we won't receive
           // a `transitioning = true` notification.
-          if (this.renderer.transitioning) {
+          if (this.renderer && this.renderer.transitioning) {
             this._toggleListeners();
             this.applyFocus();
           }

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -193,11 +193,6 @@ styling can be done like this:
           };
         }
 
-        connectedCallback() {
-          super.connectedCallback();
-          this.opened && this._openedChanged(this.opened);
-        }
-
         disconnectedCallback() {
           super.disconnectedCallback();
           this._ensureDetached();
@@ -214,26 +209,14 @@ styling can be done like this:
           if (this.opened) {
             this._getFocusNode().focus();
           } else {
-            // Find if the focus is in the renderer.
-            let active = document.activeElement;
-            // Consider <body> as null.
-            if (active === document.body) {
+            // Find if the focus is in the renderer by looking at
+            // the active element in the root node containing the renderer.
+            let active = this.renderer.getRootNode().activeElement;
+            if (active === document.body || this.renderer.contains(active)) {
+              active.blur();
               active = null;
             }
-            while (active) {
-              // The focus is in the renderer!
-              if (this.renderer.contains(active)) {
-                active.blur();
-                active = null;
-                break;
-              }
-              // Keep searching into shadowRoot's activeElement.
-              if (!active.shadowRoot) {
-                break;
-              }
-              active = active.shadowRoot.activeElement;
-            }
-            // If the activeElement is null, we are allowed to restore
+            // If there is no activeElement, we are allowed to restore
             // the focus. In all the other cases focus might have been moved
             // elsewhere by another component or by an user interaction
             // (e.g. click on a button outside the overlay).

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer-element.html">
-<link rel="import" href="../polymer/lib/utils/gestures.html">
 <link rel="import" href="../polymer/lib/utils/templatize.html">
 <link rel="import" href="iron-overlay-renderer.html">
 <link rel="import" href="shared-event-listener.html">
@@ -44,7 +43,7 @@ overlays. Insert it in a stacking-context safe node (e.g. `document.body`).
 
 An overlay may be hidden by closing or canceling. The difference between close and cancel is user
 intent. Closing generally implies that the user acknowledged the content on the overlay. By default,
-it will cancel whenever the user taps outside it or presses the escape key. This behavior is
+it will cancel whenever the user clicks outside it or presses the escape key. This behavior is
 configurable with the `no-cancel-on-esc-key` and the `no-cancel-on-outside-click` properties.
 `close()` should be called explicitly by the implementer when the user interacts with a control
 in the overlay element. When the overlay is canceled, it fires an 'iron-overlay-canceled'
@@ -188,7 +187,7 @@ styling can be done like this:
             },
 
             /**
-             * A shared event listener to handle interactions like tap or keydown.
+             * A shared event listener to handle interactions like click or keydown.
              * The last overlay opened will be the last to listen for events, but should
              * be the first to handle the event. The shared event listener allows this, delegating
              * the handling of the event to the last one listening for it.
@@ -289,10 +288,10 @@ styling can be done like this:
          */
         _toggleListeners() {
           if (this.opened) {
-            this._sharedListener.listen('tap', this, '_onTap');
-            this._sharedListener.listen('keydown', this, '_onKeydown');
+            this._sharedListener.listen('click', this, '_captureOutsideClick');
+            this._sharedListener.listen('keydown', this, '_captureEscapeKey');
           } else {
-            this._sharedListener.unlisten('tap', this);
+            this._sharedListener.unlisten('click', this);
             this._sharedListener.unlisten('keydown', this);
           }
         }
@@ -341,7 +340,7 @@ styling can be done like this:
          * @param {!Event} event
          * @return {boolean} handled
          */
-        _onKeydown(event) {
+        _captureEscapeKey(event) {
           // By default the overlay says it handles this event. It should say
           // it does not handle it if the user has pressed ESC and noCancelOnEscKey
           // is true.
@@ -365,12 +364,12 @@ styling can be done like this:
          * @param {!Event} event
          * @return {boolean} handled
          */
-        _onTap(event) {
+        _captureOutsideClick(event) {
           // By default the overlay says it handles this event. It should say
           // it does not handle it if the user has clicked outside the overlay
           // and noCancelOnOutsideClick is true.
           let handled = true;
-          if (this._isTapOutside(event)) {
+          if (this._isClickOutside(event)) {
             if (this.noCancelOnOutsideClick) {
               handled = false;
             } else {
@@ -384,7 +383,7 @@ styling can be done like this:
          * @param {!Event} event
          * @returns {boolean}
          */
-        _isTapOutside(event) {
+        _isClickOutside(event) {
           return event.composedPath().indexOf(this.renderer) === -1;
         }
 

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -88,7 +88,6 @@ styling can be done like this:
     (() => {
       'use strict';
 
-      const sharedListener = new Polymer.SharedEventListener();
       const contentHostGenerator = new Polymer.ScopingHostGenerator('iron-overlay-content-host');
 
       class IronOverlay extends Polymer.Element {
@@ -169,15 +168,36 @@ styling can be done like this:
 
             /**
              * The host of the content.
+             * @type {Element|DocumentFragment}
              */
             contentHost: {
-              type: Element,
+              type: Object,
               readOnly: true
             },
 
+            /**
+             * The node where focus should be restored once the overlay is closed.
+             * Focus will be restored there only if nothing else is focused (e.g. if user
+             * clicked another button and overlay got closed, we don't restore focus).
+             * @type {Node}
+             * @protected
+             */
             _restoreFocusNode: {
-              type: Node,
+              type: Object,
               value: null
+            },
+
+            /**
+             * A shared event listener to handle interactions like tap or keydown.
+             * The last overlay opened will be the last to listen for events, but should
+             * be the first to handle the event. The shared event listener allows this, delegating
+             * the handling of the event to the last one listening for it.
+             * @protected
+             */
+            _sharedListener: {
+              type: Object,
+              readOnly: true,
+              value: new Polymer.SharedEventListener()
             }
           };
         }
@@ -286,11 +306,11 @@ styling can be done like this:
          */
         _toggleListeners() {
           if (this.opened) {
-            sharedListener.listen('tap', this, '_onTap');
-            sharedListener.listen('keydown', this, '_onKeydown');
+            this._sharedListener.listen('tap', this, '_onTap');
+            this._sharedListener.listen('keydown', this, '_onKeydown');
           } else {
-            sharedListener.unlisten('tap', this);
-            sharedListener.unlisten('keydown', this);
+            this._sharedListener.unlisten('tap', this);
+            this._sharedListener.unlisten('keydown', this);
           }
         }
 

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -189,18 +189,37 @@ styling can be done like this:
             _restoreFocusNode: {
               type: Object,
               value: null
+            },
+
+            /**
+             * Wether the opened should be restored to true on next attach.
+             * @type {Boolean}
+             * @private
+             */
+            __restoreOpened: {
+              type: Boolean
             }
           };
         }
+
         connectedCallback() {
           super.connectedCallback();
-          this.opened && this._ensureAttached();
+          if (this.__restoreOpened) {
+            this.opened = true;
+          } else if (this.opened) {
+            this._ensureAttached();
+          }
         }
 
         disconnectedCallback() {
           super.disconnectedCallback();
           // Force closing.
-          this.opened = false;
+          if (this.opened) {
+            this.opened = false;
+            // Should restore at next attach. If someone changes
+            // it, _openedChanged will reset this boolean.
+            this.__restoreOpened = true;
+          }
         }
 
         /**
@@ -419,6 +438,8 @@ styling can be done like this:
         }
 
         _openedChanged(opened) {
+          // Someone modified `opened`, do not restore it.
+          this.__restoreOpened = false;
           // Reset the closing reason to false.
           this.closingReason.canceled = false;
           if (opened) {

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -259,7 +259,7 @@ styling can be done like this:
          * @protected
          */
         _getFocusNode() {
-          return this.renderer.querySelector('[autofocus]') || this.renderer;
+          return this.contentHost.querySelector('[autofocus]') || this.renderer;
         }
 
         /**

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -144,7 +144,25 @@ styling can be done like this:
         }
       }
 
+      class ScopingHostGenerator {
+        constructor(hostNamePrefix) {
+          this._count = 0;
+          this._prefix = hostNamePrefix;
+        }
+        generate(template) {
+          const hostName = this._prefix + '-' + this._count++;
+          window.ShadyCSS && ShadyCSS.prepareTemplate(template, hostName);
+          const el = document.createElement(hostName);
+          el.attachShadow({
+            mode: 'open'
+          });
+          window.ShadyCSS && ShadyCSS.styleElement(el);
+          return el;
+        }
+      }
+
       const sharedListener = new SharedEventListener();
+      const contentHostGenerator = new ScopingHostGenerator('content-host');
 
       class IronOverlay extends Polymer.Element {
 
@@ -361,25 +379,21 @@ styling can be done like this:
           // Stamp the content (if any)
           const contentTemplate = this.querySelector('template');
           if (contentTemplate) {
+            // Scope styles by creating an intermediate element's shadowRoot.
+            if (contentTemplate.content.querySelector('style')) {
+              const el = contentHostGenerator.generate(contentTemplate);
+              renderer.appendChild(el);
+              this._contentHost = el.shadowRoot;
+            } else {
+              this._contentHost = renderer;
+            }
             this.__contentInstance = new(Polymer.Templatize.templatize(contentTemplate, this, {
               forwardHostProp(prop, value) {
                 this.__contentInstance && this.__contentInstance.forwardHostProp(prop, value);
               }
             }))();
-            // Scope styles by creating an intermediate shadowRoot.
-            if (this.__contentInstance.root.querySelector('style')) {
-              const el = document.createElement('div');
-              el.attachShadow({
-                mode: 'open'
-              }).appendChild(this.__contentInstance.root);
-              // Provide some way to query for the content.
-              this._contentHost = el.shadowRoot;
-              renderer.appendChild(el);
-            } else {
-              this._contentHost = renderer;
-              // Append children to renderer.
-              renderer.appendChild(this.__contentInstance.root);
-            }
+            // Append children to renderer.
+            this._contentHost.appendChild(this.__contentInstance.root);
           }
           return renderer;
         }

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -316,13 +316,9 @@ styling can be done like this:
           const contentTemplate = this.querySelector('template');
           if (contentTemplate) {
             // Scope styles by creating an intermediate element's shadowRoot.
-            if (contentTemplate.content.querySelector('style')) {
-              const el = _contentHostGenerator.generate(contentTemplate);
-              renderer.appendChild(el);
-              this._setContentHost(el.shadowRoot);
-            } else {
-              this._setContentHost(renderer);
-            }
+            const el = _contentHostGenerator.generate(contentTemplate);
+            renderer.appendChild(el);
+            this._setContentHost(el.shadowRoot);
             this.__contentInstance = new(Polymer.Templatize.templatize(contentTemplate, this, {
               forwardHostProp(prop, value) {
                 this.__contentInstance && this.__contentInstance.forwardHostProp(prop, value);

--- a/iron-overlay.html
+++ b/iron-overlay.html
@@ -370,10 +370,13 @@ styling can be done like this:
             if (this.__contentInstance.root.querySelector('style')) {
               const el = document.createElement('div');
               el.attachShadow({
-                mode: 'open' //TODO(valdrin) consider mode: 'closed'
+                mode: 'open'
               }).appendChild(this.__contentInstance.root);
+              // Provide some way to query for the content.
+              this._contentHost = el.shadowRoot;
               renderer.appendChild(el);
             } else {
+              this._contentHost = renderer;
               // Append children to renderer.
               renderer.appendChild(this.__contentInstance.root);
             }

--- a/scoping-host-generator.html
+++ b/scoping-host-generator.html
@@ -8,18 +8,15 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../polymer/polymer-element.html">
-
 <script>
   (() => {
     'use strict';
-
     /**
      * ScopingHostGenerator allows to create an element with a shadow root.
      * The generated element can be used to scope styles by inserting content
      * in its shadowRoot.
      */
-    Polymer.ScopingHostGenerator = class ScopingHostGenerator {
+    window.ScopingHostGenerator = class ScopingHostGenerator {
       /**
        * @type {!string} hostTagName
        */

--- a/scoping-host-generator.html
+++ b/scoping-host-generator.html
@@ -1,0 +1,54 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer-element.html">
+
+<script>
+  (() => {
+    'use strict';
+
+    /**
+     * ScopingHostGenerator allows to create an element with a shadow root.
+     * The generated element can be used to scope styles by inserting content
+     * in its shadowRoot.
+     */
+    Polymer.ScopingHostGenerator = class ScopingHostGenerator {
+      /**
+       * @type {!string} hostTagName
+       */
+      constructor(hostTagName) {
+        this._count = 0;
+        this._hostTagName = hostTagName;
+      }
+      /**
+       * Generates an element with a shadowRoot, and styles it to host
+       * the template.
+       * @type {!HTMLTemplateElement} template
+       * @return {HTMLElement}
+       */
+      generate(template) {
+        let hostTagName = this._hostTagName;
+        // NOTE: we create a different element since ShadyCSS cannot
+        // handle multiple templates for a single shadowRoot.
+        if (window.ShadyCSS) {
+          hostTagName += '-' + this._count;
+          template && ShadyCSS.prepareTemplate(template, hostTagName);
+        }
+        const el = document.createElement(hostTagName);
+        el.attachShadow({
+          mode: 'open'
+        });
+        window.ShadyCSS && ShadyCSS.styleElement(el);
+        this._count++;
+        return el;
+      }
+    };
+  })();
+</script>

--- a/scoping-host-generator.html
+++ b/scoping-host-generator.html
@@ -33,7 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       generate(template) {
         const needsScoping = window.ShadyCSS && (!ShadyCSS.nativeCss || !ShadyCSS.nativeShadow);
         // NOTE: we create a different element since ShadyCSS cannot
-        // handle multiple templates for a single shadowRoot.
+        // handle multiple templates for a single shadowRoot webcomponents/shadycss#115
         const hostTagName = this._hostTagName + (needsScoping ? '-' + this._count++ : '');
         const el = document.createElement(hostTagName);
         el.attachShadow({

--- a/scoping-host-generator.html
+++ b/scoping-host-generator.html
@@ -31,19 +31,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {HTMLElement}
        */
       generate(template) {
-        let hostTagName = this._hostTagName;
+        const needsScoping = window.ShadyCSS && (!ShadyCSS.nativeCss || !ShadyCSS.nativeShadow);
         // NOTE: we create a different element since ShadyCSS cannot
         // handle multiple templates for a single shadowRoot.
-        if (window.ShadyCSS) {
-          hostTagName += '-' + this._count;
-          template && ShadyCSS.prepareTemplate(template, hostTagName);
-        }
+        const hostTagName = this._hostTagName + (needsScoping ? '-' + this._count++ : '');
         const el = document.createElement(hostTagName);
         el.attachShadow({
           mode: 'open'
         });
-        window.ShadyCSS && ShadyCSS.styleElement(el);
-        this._count++;
+        if (needsScoping) {
+          ShadyCSS.prepareTemplate(template, hostTagName);
+          ShadyCSS.styleElement(el);
+        }
         return el;
       }
     };

--- a/shared-event-listener.html
+++ b/shared-event-listener.html
@@ -1,0 +1,76 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer-element.html">
+
+<script>
+  (() => {
+    'use strict';
+
+    /**
+     * SharedEventListener allows to register callback for an event on document
+     * ensuring that the last registered callback is the one called.
+     * e.g. `node1`, `node2`, then `node3` listen for `click` event -> `node3`
+     * is the one to handle it.
+     */
+    Polymer.SharedEventListener = class SharedEventListener {
+
+      constructor() {
+        this._events = {};
+        this._handleEvent = this._handleEvent.bind(this);
+        // Enable document-wide gesture recognizer.
+        Polymer.Gestures.addListener(document, 'tap', null);
+      }
+
+      /**
+       * Expects a callback that returns true when it handles the event, false
+       * to allow the event to be handled by the next listener.
+       */
+      listen(eventName, listener, callback) {
+        if (!this._events[eventName]) {
+          this._events[eventName] = [];
+          document.addEventListener(eventName, this._handleEvent, {
+            capture: true
+          });
+        }
+        // It's fine if we have duplicates, as the last one counts.
+        this._events[eventName].push({
+          listener: listener,
+          callback: callback
+        });
+      }
+
+      unlisten(eventName, listener) {
+        if (!this._events[eventName]) {
+          return;
+        }
+        // Remove all matching listeners.
+        const listeners = this._events[eventName].filter(obj => obj.listener !== listener);
+        if (listeners.length) {
+          this._events[eventName] = listeners;
+        } else {
+          this._events[eventName] = null;
+          document.removeEventListener(eventName, this._handleEvent, {
+            capture: true
+          });
+        }
+      }
+
+      _handleEvent(event) {
+        const handlers = this._events[event.type];
+        let i = handlers.length - 1;
+        let handler = null;
+        while ((handler = handlers[i--]) && !handler.listener[handler.callback](event)) {
+          // Keep looping until someone handles the event.
+        }
+      }
+    };
+  })();
+</script>

--- a/shared-event-listener.html
+++ b/shared-event-listener.html
@@ -25,8 +25,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       constructor() {
         this._events = {};
         this._handleEvent = this._handleEvent.bind(this);
-        // Enable document-wide gesture recognizer.
-        Polymer.Gestures.addListener(document, 'tap', null);
       }
 
       /**

--- a/shared-event-listener.html
+++ b/shared-event-listener.html
@@ -8,25 +8,20 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../polymer/polymer-element.html">
-
 <script>
   (() => {
     'use strict';
-
     /**
-     * SharedEventListener allows to register callback for an event on document
-     * ensuring that the last registered callback is the one called.
+     * SharedEventListener allows to register callback for an event on
+     * document ensuring that the last registered callback is the one called.
      * e.g. `node1`, `node2`, then `node3` listen for `click` event -> `node3`
      * is the one to handle it.
      */
-    Polymer.SharedEventListener = class SharedEventListener {
-
+    window.SharedEventListener = class SharedEventListener {
       constructor() {
         this._events = {};
         this._handleEvent = this._handleEvent.bind(this);
       }
-
       /**
        * Expects a callback that returns true when it handles the event, false
        * to allow the event to be handled by the next listener.
@@ -44,7 +39,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           callback: callback
         });
       }
-
       unlisten(eventName, listener) {
         if (!this._events[eventName]) {
           return;
@@ -60,7 +54,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         }
       }
-
       _handleEvent(event) {
         const handlers = this._events[event.type];
         let i = handlers.length - 1;

--- a/test/iron-overlay-container.html
+++ b/test/iron-overlay-container.html
@@ -43,32 +43,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-    suite('<iron-overlay-container>', function() {
-      var container;
-      var overlay1;
-      var overlay2;
+    suite('<iron-overlay-container>', () => {
+      let container;
+      let overlay1;
+      let overlay2;
 
-      setup(function() {
+      setup(() => {
         container = fixture('basic');
-        var overlays = fixture('overlays');
+        const overlays = fixture('overlays');
         overlay1 = overlays[0];
         overlay2 = overlays[1];
       });
 
-      test('handles iron-overlay-attach', function() {
+      test('handles iron-overlay-attach', () => {
         assert.isTrue(overlay1.fireAttach().defaultPrevented, 'event handled');
         assert.equal(overlay1.renderer.parentNode, container, 'renderer hosted');
         assert.equal(overlay1, container.currentOverlay, 'currentOverlay updated');
       });
 
-      test('handles iron-overlay-detach', function() {
+      test('handles iron-overlay-detach', () => {
         overlay1.fireAttach();
         assert.isTrue(overlay1.fireDetach().defaultPrevented, 'event handled');
         assert.isNotOk(overlay1.renderer.parentNode, 'renderer detached');
         assert.isNotOk(container.currentOverlay, 'currentOverlay updated');
       });
 
-      test('detach and attach to bring overlay on top', function() {
+      test('detach and attach to bring overlay on top', () => {
         overlay1.fireAttach();
         overlay2.fireAttach();
         assert.equal(overlay2, container.currentOverlay, 'renderer2 on top');

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -348,14 +348,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           .catch(done);
       });
 
-      test('reparent overlay', done => {
-        const parent = overlay.parentNode;
+      test('reparenting overlay keeps it opened', done => {
         openPromise(overlay)
           .then(() => {
             document.body.appendChild(overlay);
-            assert.isFalse(overlay.opened, 'overlay not closed');
+            assert.isTrue(overlay.opened, 'overlay not opened');
+            return waitNextEvent(overlay, 'iron-overlay-opened');
+          })
+          .then(() => done())
+          .catch(done);
+      });
+
+      test('focus restoring works when reparenting overlay', done => {
+        const parent = overlay.parentNode;
+        openPromise(overlay)
+          .then(() => {
             button0.focus();
-            return openPromise(overlay);
+            document.body.appendChild(overlay);
+            return waitNextEvent(overlay, 'iron-overlay-opened');
           })
           .then(() => closePromise(overlay))
           .then(() => {

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -45,14 +45,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="scoped">
     <template>
-      <iron-overlay opened>
+      <iron-overlay>
         <template>
           <style>
             * {
               color: red;
             }
           </style>
-          <button>click</button>
+          <button autofocus>autofocused</button>
         </template>
       </iron-overlay>
     </template>
@@ -93,17 +93,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-    var overlay;
-
-    function runAfterOpen(overlay, callback) {
-      overlay.addEventListener('iron-overlay-opened', callback);
-      overlay.opened = true;
-    }
-
-    function runAfterClose(overlay, callback) {
-      overlay.addEventListener('iron-overlay-closed', callback);
-      overlay.opened = false;
-    }
+    let overlay;
 
     suite('basic overlay', function() {
 
@@ -140,7 +130,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('overlay fires iron-overlay-opened', function(done) {
-        var spy = sinon.stub();
+        const spy = sinon.stub();
         overlay.addEventListener('iron-overlay-opened', spy);
         runAfterOpen(overlay, function() {
           assert.isTrue(spy.calledOnce, 'opened event fired once');
@@ -149,7 +139,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('overlay fires iron-overlay-closed', function(done) {
-        var spy = sinon.stub();
+        const spy = sinon.stub();
         overlay.addEventListener('iron-overlay-opened', spy);
         overlay.addEventListener('iron-overlay-closed', spy);
         runAfterOpen(overlay, function() {
@@ -175,7 +165,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('clicking an overlay does not close it', function(done) {
         runAfterOpen(overlay, function() {
-          var spy = sinon.stub();
+          const spy = sinon.stub();
           overlay.addEventListener('iron-overlay-closed', spy);
           MockInteractions.tap(overlay.renderer.$.overlay);
           setTimeout(function() {
@@ -186,8 +176,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('open overlay on mousedown does not close it', function(done) {
-        var btn = document.createElement('button');
-        btn.addEventListener('mousedown', overlay.open.bind(overlay));
+        const btn = document.createElement('button');
+        btn.addEventListener('mousedown', () => overlay.opened = true);
         document.body.appendChild(btn);
         // It triggers mousedown, mouseup, and click.
         MockInteractions.tap(btn);
@@ -225,7 +215,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           overlay.addEventListener('iron-overlay-canceled', function(event) {
             event.preventDefault();
           });
-          var spy = sinon.stub();
+          const spy = sinon.stub();
           overlay.addEventListener('iron-overlay-closed', spy);
           MockInteractions.tap(document.body);
           setTimeout(function() {
@@ -259,7 +249,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('no-cancel-on-outside-click property', function(done) {
         overlay.noCancelOnOutsideClick = true;
         runAfterOpen(overlay, function() {
-          var spy = sinon.stub();
+          const spy = sinon.stub();
           overlay.addEventListener('iron-overlay-closed', spy);
           MockInteractions.tap(document.body);
           setTimeout(function() {
@@ -272,7 +262,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('no-cancel-on-esc-key property', function(done) {
         overlay.noCancelOnEscKey = true;
         runAfterOpen(overlay, function() {
-          var spy = sinon.stub();
+          const spy = sinon.stub();
           overlay.addEventListener('iron-overlay-closed', spy);
           MockInteractions.pressAndReleaseKeyOn(document, 27);
           setTimeout(function() {
@@ -297,7 +287,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('overlay positioned & sized properly', function(done) {
         setTimeout(function() {
-          var rect = overlay.renderer.$.overlay.getBoundingClientRect();
+          const rect = overlay.renderer.$.overlay.getBoundingClientRect();
           assert.closeTo(rect.left, (window.innerWidth - rect.width) / 2, 1, 'centered horizontally');
           assert.closeTo(rect.top, (window.innerHeight - rect.height) / 2, 1, 'centered vertically');
           done();
@@ -305,68 +295,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
-    suite('focus handling', function() {
+    focusSuiteForFixture('basic');
 
-      setup(function() {
-        overlay = fixture('basic');
-      });
-
-      test('node with autofocus is focused', function(done) {
-        runAfterOpen(overlay, function() {
-          assert.isTrue(overlay.contentHost.contains(document.activeElement),
-            '<button autofocus> is focused');
-          done();
-        });
-      });
-
-      test('no-auto-focus will not focus node with autofocus', function(done) {
-        overlay.noAutoFocus = true;
-        runAfterOpen(overlay, function() {
-          assert.isFalse(overlay.contentHost.contains(document.activeElement),
-            '<button autofocus> not focused after opened');
-          done();
-        });
-        // In Safari the element with autofocus will immediately receive focus when displayed for the first time http://jsbin.com/woroci/2/ Ensure this is not the case for overlay.
-        assert.isFalse(overlay.contentHost.contains(document.activeElement),
-          '<button autofocus> not immediately focused');
-      });
-
-      suite('restore focus', function() {
-        let buttons;
-        setup(function() {
-          buttons = fixture('buttons');
-        });
-
-        test('restores focus to previous focusable', function(done) {
-          buttons[0].focus();
-          runAfterOpen(overlay, function() {
-            runAfterClose(overlay, function() {
-              assert.equal(document.activeElement, buttons[0], 'focus returned to button');
-              done();
-            });
-          });
-        });
-
-        test('avoids restoring focus if focus changed', function(done) {
-          buttons[0].focus();
-          runAfterOpen(overlay, function() {
-            buttons[1].focus();
-            runAfterClose(overlay, function() {
-              assert.equal(document.activeElement, buttons[1], 'focus was not modified');
-              done();
-            });
-          });
-        });
-      });
-
-    });
+    focusSuiteForFixture('scoped');
 
     suite('multiple overlays', function() {
-      var overlay1,
+      let overlay1,
         overlay2;
 
       setup(function() {
-        var f = fixture('multiple');
+        const f = fixture('multiple');
         overlay1 = f[0];
         overlay2 = f[1];
       });
@@ -411,7 +349,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         runAfterOpen(overlay1, function() {
           runAfterOpen(overlay2, function() {
             const button = overlay2.contentHost.querySelector('button');
-            button.addEventListener('tap', overlay2.close.bind(overlay2));
+            button.addEventListener('tap', () => overlay2.opened = false);
             MockInteractions.tap(button);
             assert.isFalse(overlay2.opened, 'overlay2 closed');
             assert.isTrue(overlay1.opened, 'overlay1 still opened');
@@ -440,6 +378,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       setup(function() {
         overlay = fixture('scoped');
+        overlay.opened = true;
       });
 
       test('can query content', function() {
@@ -447,7 +386,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('can listen to non-composed events content', function() {
-        var spy = sinon.spy();
+        const spy = sinon.spy();
         overlay.contentHost.addEventListener('some-event', spy);
         overlay.contentHost.querySelector('button').dispatchEvent(new CustomEvent('some-event', {
           bubbles: true,
@@ -470,6 +409,84 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
     });
+
+    function runAfterOpen(overlay, callback) {
+      overlay.addEventListener('iron-overlay-opened', callback);
+      overlay.opened = true;
+    }
+
+    function runAfterClose(overlay, callback) {
+      overlay.addEventListener('iron-overlay-closed', callback);
+      overlay.opened = false;
+    }
+
+    function getDeepActiveElement() {
+      let active = document.activeElement;
+      while (active && active.shadowRoot && active.shadowRoot.activeElement) {
+        active = active.shadowRoot.activeElement;
+      }
+      return active;
+    }
+
+    function focusSuiteForFixture(fixtureName) {
+      return suite(fixtureName + ' overlay focus handling', function() {
+
+        setup(function() {
+          overlay = fixture(fixtureName);
+        });
+
+        test('node with autofocus is focused', function(done) {
+          runAfterOpen(overlay, function() {
+            assert.isTrue(overlay.contentHost.contains(getDeepActiveElement()),
+              '<button autofocus> is focused');
+            done();
+          });
+        });
+
+        test('no-auto-focus will not focus node with autofocus', function(done) {
+          overlay.noAutoFocus = true;
+          runAfterOpen(overlay, function() {
+            assert.isFalse(overlay.contentHost.contains(getDeepActiveElement()),
+              '<button autofocus> not focused after opened');
+            done();
+          });
+          // In Safari the element with autofocus will immediately receive focus when displayed for the first time http://jsbin.com/woroci/2/ Ensure this is not the case for overlay.
+          assert.isFalse(overlay.contentHost.contains(getDeepActiveElement()),
+            '<button autofocus> not immediately focused');
+        });
+
+        suite('restore focus', function() {
+          let buttons;
+          setup(function(done) {
+            buttons = fixture('buttons');
+            buttons[0].focus();
+            // setTimeout(function() {
+            done();
+            // });
+          });
+
+          test('restores focus to previous focusable', function(done) {
+            runAfterOpen(overlay, function() {
+              runAfterClose(overlay, function() {
+                assert.equal(getDeepActiveElement(), buttons[0], 'focus returned to button');
+                done();
+              });
+            });
+          });
+
+          test('avoids restoring focus if focus changed', function(done) {
+            runAfterOpen(overlay, function() {
+              buttons[1].focus();
+              runAfterClose(overlay, function() {
+                assert.equal(getDeepActiveElement(), buttons[1], 'focus was not modified');
+                done();
+              });
+            });
+          });
+        });
+
+      });
+    }
   </script>
 
 </body>

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -303,7 +303,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('node with autofocus is focused', function(done) {
         runAfterOpen(overlay, function() {
-          assert.isTrue(overlay._contentHost.contains(document.activeElement), '<button autofocus> is focused');
+          assert.isTrue(overlay.contentHost.contains(document.activeElement), '<button autofocus> is focused');
           done();
         });
       });
@@ -311,12 +311,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('no-auto-focus will not focus node with autofocus', function(done) {
         overlay.noAutoFocus = true;
         runAfterOpen(overlay, function() {
-          assert.isFalse(overlay._contentHost.contains(document.activeElement), document.activeElement,
+          assert.isFalse(overlay.contentHost.contains(document.activeElement), document.activeElement,
             '<button autofocus> not focused after opened');
           done();
         });
         // In Safari the element with autofocus will immediately receive focus when displayed for the first time http://jsbin.com/woroci/2/ Ensure this is not the case for overlay.
-        assert.isFalse(overlay._contentHost.contains(document.activeElement),
+        assert.isFalse(overlay.contentHost.contains(document.activeElement),
           '<button autofocus> not immediately focused');
       });
 
@@ -409,7 +409,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overlay2.noCancelOnOutsideClick = true;
         runAfterOpen(overlay1, function() {
           runAfterOpen(overlay2, function() {
-            const button = overlay2._contentHost.querySelector('button');
+            const button = overlay2.contentHost.querySelector('button');
             button.addEventListener('tap', overlay2.close.bind(overlay2));
             MockInteractions.tap(button);
             assert.isFalse(overlay2.opened, 'overlay2 closed');
@@ -439,8 +439,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overlay2.opened = true;
         // Force distribution & styling.
         window.ShadyDOM && ShadyDOM.flush();
-        var btn1 = overlay1._contentHost.querySelector('button');
-        var btn2 = overlay2._contentHost.querySelector('button');
+        var btn1 = overlay1.contentHost.querySelector('button');
+        var btn2 = overlay2.contentHost.querySelector('button');
         assert.notEqual(getComputedStyle(btn1).color, 'rgb(255, 0, 0)', 'overlay1 btn color ok');
         assert.equal(getComputedStyle(btn2).color, 'rgb(255, 0, 0)', 'overlay2 btn color ok');
       });

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -43,6 +43,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="scoped">
+    <template>
+      <iron-overlay opened>
+        <template>
+          <style>
+            * {
+              color: red;
+            }
+          </style>
+          <button>click</button>
+        </template>
+      </iron-overlay>
+    </template>
+  </test-fixture>
+
   <test-fixture id="opened">
     <template>
       <iron-overlay opened>
@@ -63,11 +78,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </iron-overlay>
       <iron-overlay class="overlay-2">
         <template>
-          <style>
-            button {
-              color: red;
-            }
-          </style>
           Test overlay 2
           <button>Click</button>
         </template>
@@ -303,7 +313,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('node with autofocus is focused', function(done) {
         runAfterOpen(overlay, function() {
-          assert.isTrue(overlay.contentHost.contains(document.activeElement), '<button autofocus> is focused');
+          assert.isTrue(overlay.contentHost.contains(document.activeElement),
+            '<button autofocus> is focused');
           done();
         });
       });
@@ -433,16 +444,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         })
       });
 
+    });
+
+    suite('scoped overlay', function() {
+
+      setup(function() {
+        overlay = fixture('scoped');
+      });
+
+      test('can query content', function() {
+        assert.isOk(overlay.contentHost.querySelector('button'));
+      });
+
+      test('can listen to non-composed events content', function() {
+        var spy = sinon.spy();
+        overlay.contentHost.addEventListener('some-event', spy);
+        overlay.contentHost.querySelector('button').dispatchEvent(new CustomEvent('some-event', {
+          bubbles: true,
+          composed: false
+        }));
+        assert.equal(spy.callCount, 1);
+      });
+
       test('styles are scoped', function() {
-        // Open so content is created
-        overlay1.opened = true;
-        overlay2.opened = true;
         // Force distribution & styling.
         window.ShadyDOM && ShadyDOM.flush();
-        var btn1 = overlay1.contentHost.querySelector('button');
-        var btn2 = overlay2.contentHost.querySelector('button');
-        assert.notEqual(getComputedStyle(btn1).color, 'rgb(255, 0, 0)', 'overlay1 btn color ok');
-        assert.equal(getComputedStyle(btn2).color, 'rgb(255, 0, 0)', 'overlay2 btn color ok');
+        assert.notEqual(
+          getComputedStyle(overlay.renderer).color,
+          'rgb(255, 0, 0)',
+          'outside content color ok');
+        assert.equal(
+          getComputedStyle(overlay.contentHost.querySelector('button')).color,
+          'rgb(255, 0, 0)',
+          'content in overlay color ok');
       });
 
     });

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -85,13 +85,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <test-fixture id="buttons">
-    <template>
-      <button>button</button>
-      <button>button</button>
-    </template>
-  </test-fixture>
-
+  <button id="button0">button0</button>
+  <button id="button1">button1</button>
   <script>
     let overlay;
 
@@ -311,6 +306,66 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    const waitNextEvent = (el, event) =>
+      new Promise(resolve => el.addEventListener(event, resolve));
+
+    const openPromise = overlay => {
+      overlay.opened = true;
+      return waitNextEvent(overlay, 'iron-overlay-opened');
+    };
+
+    const closePromise = overlay => {
+      overlay.opened = false;
+      return waitNextEvent(overlay, 'iron-overlay-closed');
+    };
+
+    suite('attach/detach', function() {
+
+      setup(function() {
+        overlay = fixture('basic');
+      });
+
+      test('detached overlay does not create the renderer', function(done) {
+        const spy = sinon.stub();
+        overlay.addEventListener('iron-overlay-opened', spy);
+        overlay.parentNode.removeChild(overlay);
+        overlay.opened = true;
+        assert.isNotOk(overlay.renderer, 'renderer not initialized');
+        setTimeout(function() {
+          assert.isFalse(spy.called, 'iron-overlay-opened should not fire');
+          done();
+        }, 100);
+      });
+
+      test('removing overlay from the DOM closes it', function(done) {
+        openPromise(overlay)
+          .then(() => {
+            overlay.parentNode.removeChild(overlay);
+            assert.isFalse(overlay.opened, 'overlay not closed');
+            return waitNextEvent(overlay, 'iron-overlay-closed');
+          })
+          .then(() => done())
+          .catch(done);
+      });
+
+      test('reparent overlay', function(done) {
+        const parent = overlay.parentNode;
+        openPromise(overlay)
+          .then(() => {
+            document.body.appendChild(overlay);
+            assert.isFalse(overlay.opened, 'overlay not closed');
+            button0.focus();
+            return openPromise(overlay);
+          })
+          .then(() => closePromise(overlay))
+          .then(() => {
+            assert.equal(getDeepActiveElement(), button0, 'focus not returned to button');
+            done();
+          })
+          .catch(done);
+      });
+    });
+
     focusSuiteForFixture('basic');
 
     focusSuiteForFixture('scoped');
@@ -475,16 +530,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         suite('restore focus', function() {
-          let buttons;
           setup(function() {
-            buttons = fixture('buttons');
-            buttons[0].focus();
+            button0.focus();
           });
 
           test('restores focus to previous focusable', function(done) {
             runAfterOpen(overlay, function() {
               runAfterClose(overlay, function() {
-                assert.equal(getDeepActiveElement(), buttons[0], 'focus returned to button');
+                assert.equal(getDeepActiveElement(), button0, 'focus returned to button');
                 done();
               });
             });
@@ -492,9 +545,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           test('avoids restoring focus if focus changed', function(done) {
             runAfterOpen(overlay, function() {
-              buttons[1].focus();
+              button1.focus();
               runAfterClose(overlay, function() {
-                assert.equal(getDeepActiveElement(), buttons[1], 'focus was not modified');
+                assert.equal(getDeepActiveElement(), button1, 'focus was not modified');
                 done();
               });
             });

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -437,7 +437,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('node with autofocus is focused', function(done) {
           runAfterOpen(overlay, function() {
-            assert.isTrue(overlay.contentHost.contains(getDeepActiveElement()),
+            const autofocused = overlay.contentHost.querySelector('[autofocus]');
+            assert.equal(getDeepActiveElement(), autofocused,
               '<button autofocus> is focused');
             done();
           });
@@ -446,23 +447,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('no-auto-focus will not focus node with autofocus', function(done) {
           overlay.noAutoFocus = true;
           runAfterOpen(overlay, function() {
-            assert.isFalse(overlay.contentHost.contains(getDeepActiveElement()),
+            const autofocused = overlay.contentHost.querySelector('[autofocus]');
+            assert.notEqual(getDeepActiveElement(), autofocused,
               '<button autofocus> not focused after opened');
             done();
           });
           // In Safari the element with autofocus will immediately receive focus when displayed for the first time http://jsbin.com/woroci/2/ Ensure this is not the case for overlay.
-          assert.isFalse(overlay.contentHost.contains(getDeepActiveElement()),
+          const autofocused = overlay.contentHost.querySelector('[autofocus]');
+          assert.notEqual(getDeepActiveElement(), autofocused,
             '<button autofocus> not immediately focused');
         });
 
         suite('restore focus', function() {
           let buttons;
-          setup(function(done) {
+          setup(function() {
             buttons = fixture('buttons');
             buttons[0].focus();
-            // setTimeout(function() {
-            done();
-            // });
           });
 
           test('restores focus to previous focusable', function(done) {

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -90,25 +90,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     let overlay;
 
-    suite('basic overlay', function() {
+    suite('basic overlay', () => {
 
-      setup(function() {
+      setup(() => {
         overlay = fixture('basic');
       });
 
-      test('overlay starts hidden', function() {
+      test('overlay starts hidden', () => {
         assert.isNotOk(overlay.opened, 'overlay starts closed');
         assert.isNotOk(overlay.renderer, 'overlay w/o renderer');
       });
 
-      test('overlay creates and opens the renderer', function() {
+      test('overlay creates and opens the renderer', () => {
         overlay.opened = true;
         assert.isOk(overlay.renderer, 'renderer initialized');
         assert.isTrue(overlay.renderer.opened, 'renderer opened');
       });
 
-      test('overlay delegates renderer hosting via iron-overlay-attach', function(done) {
-        overlay.addEventListener('iron-overlay-attach', function(event) {
+      test('overlay delegates renderer hosting via iron-overlay-attach', done => {
+        overlay.addEventListener('iron-overlay-attach', event => {
           assert.isTrue(event.bubbles, 'bubbling event');
           assert.isTrue(event.cancelable, 'cancelable event');
           done();
@@ -116,77 +116,77 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overlay.opened = true;
       });
 
-      test('overlay renderer attached on body', function() {
+      test('overlay renderer attached on body', () => {
         overlay.opened = true;
         assert.isTrue(document.body.contains(overlay.renderer), 'renderer attached to body');
       });
 
-      test('overlay fires iron-overlay-opened', function(done) {
+      test('overlay fires iron-overlay-opened', done => {
         const spy = sinon.stub();
         overlay.addEventListener('iron-overlay-opened', spy);
-        runAfterOpen(overlay, function() {
+        runAfterOpen(overlay, () => {
           assert.isTrue(spy.calledOnce, 'opened event fired once');
           done();
         });
       });
 
-      test('overlay fires iron-overlay-closed', function(done) {
+      test('overlay fires iron-overlay-closed', done => {
         const spy = sinon.stub();
         overlay.addEventListener('iron-overlay-opened', spy);
         overlay.addEventListener('iron-overlay-closed', spy);
-        runAfterOpen(overlay, function() {
-          runAfterClose(overlay, function() {
+        runAfterOpen(overlay, () => {
+          runAfterClose(overlay, () => {
             assert.isTrue(spy.calledTwice, 'opened and closed events fired');
             done();
           });
         });
       });
 
-      test('close an overlay quickly after open', function(done) {
+      test('close an overlay quickly after open', done => {
         // first, open the overlay
         overlay.opened = true;
-        setTimeout(function() {
+        setTimeout(() => {
           // during the opening transition, close the overlay
           this.opened = false;
           // wait for any exceptions to be thrown until the transition is done.
-          setTimeout(function() {
+          setTimeout(() => {
             done();
           }, 300);
         });
       });
 
-      test('clicking an overlay does not close it', function(done) {
-        runAfterOpen(overlay, function() {
+      test('clicking an overlay does not close it', done => {
+        runAfterOpen(overlay, () => {
           const spy = sinon.stub();
           overlay.addEventListener('iron-overlay-closed', spy);
           MockInteractions.tap(overlay.renderer.$.overlay);
-          setTimeout(function() {
+          setTimeout(() => {
             assert.isFalse(spy.called, 'iron-overlay-closed should not fire');
             done();
           }, 100);
         });
       });
 
-      test('clicking outside an overlay closes it', function(done) {
-        runAfterOpen(overlay, function() {
-          overlay.addEventListener('iron-overlay-closed', function() {
+      test('clicking outside an overlay closes it', done => {
+        runAfterOpen(overlay, () => {
+          overlay.addEventListener('iron-overlay-closed', () => {
             done();
           });
           MockInteractions.tap(document.elementFromPoint(2, 2));
         });
       });
 
-      test('clicking outside an overlay with-backdrop closes it', function(done) {
+      test('clicking outside an overlay with-backdrop closes it', done => {
         overlay.withBackdrop = true;
-        runAfterOpen(overlay, function() {
-          overlay.addEventListener('iron-overlay-closed', function() {
+        runAfterOpen(overlay, () => {
+          overlay.addEventListener('iron-overlay-closed', () => {
             done();
           });
           MockInteractions.tap(document.elementFromPoint(2, 2));
         });
       });
 
-      test('open overlay on mousedown does not close it', function(done) {
+      test('open overlay on mousedown does not close it', done => {
         const btn = document.createElement('button');
         btn.addEventListener('mousedown', () => overlay.opened = true);
         document.body.appendChild(btn);
@@ -195,15 +195,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.body.removeChild(btn);
 
         assert.isTrue(overlay.opened, 'overlay opened');
-        setTimeout(function() {
+        setTimeout(() => {
           assert.isTrue(overlay.opened, 'overlay is still open');
           done();
         }, 10);
       });
 
-      test('clicking outside fires iron-overlay-canceled', function(done) {
-        runAfterOpen(overlay, function() {
-          overlay.addEventListener('iron-overlay-canceled', function(event) {
+      test('clicking outside fires iron-overlay-canceled', done => {
+        runAfterOpen(overlay, () => {
+          overlay.addEventListener('iron-overlay-canceled', event => {
             assert.equal(event.detail.target, document.body, 'detail contains original click event');
             done();
           });
@@ -211,9 +211,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('clicking outside closes the overlay', function(done) {
-        runAfterOpen(overlay, function() {
-          overlay.addEventListener('iron-overlay-closed', function(event) {
+      test('clicking outside closes the overlay', done => {
+        runAfterOpen(overlay, () => {
+          overlay.addEventListener('iron-overlay-closed', event => {
             assert.isTrue(event.detail.canceled, 'overlay is canceled');
             done();
           });
@@ -221,15 +221,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('iron-overlay-canceled event can be prevented', function(done) {
-        runAfterOpen(overlay, function() {
-          overlay.addEventListener('iron-overlay-canceled', function(event) {
+      test('iron-overlay-canceled event can be prevented', done => {
+        runAfterOpen(overlay, () => {
+          overlay.addEventListener('iron-overlay-canceled', event => {
             event.preventDefault();
           });
           const spy = sinon.stub();
           overlay.addEventListener('iron-overlay-closed', spy);
           MockInteractions.tap(document.body);
-          setTimeout(function() {
+          setTimeout(() => {
             assert.isTrue(overlay.opened, 'overlay is still open');
             assert.isFalse(spy.called, 'iron-overlay-closed not fired');
             done();
@@ -237,9 +237,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('cancel an overlay with esc key', function(done) {
-        runAfterOpen(overlay, function() {
-          overlay.addEventListener('iron-overlay-canceled', function(event) {
+      test('cancel an overlay with esc key', done => {
+        runAfterOpen(overlay, () => {
+          overlay.addEventListener('iron-overlay-canceled', event => {
             assert.equal(event.detail.type, 'keydown');
             done();
           });
@@ -247,9 +247,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('close an overlay with esc key', function(done) {
-        runAfterOpen(overlay, function() {
-          overlay.addEventListener('iron-overlay-closed', function(event) {
+      test('close an overlay with esc key', done => {
+        runAfterOpen(overlay, () => {
+          overlay.addEventListener('iron-overlay-closed', event => {
             assert.isTrue(event.detail.canceled, 'overlay is canceled');
             done();
           });
@@ -257,26 +257,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('no-cancel-on-outside-click property', function(done) {
+      test('no-cancel-on-outside-click property', done => {
         overlay.noCancelOnOutsideClick = true;
-        runAfterOpen(overlay, function() {
+        runAfterOpen(overlay, () => {
           const spy = sinon.stub();
           overlay.addEventListener('iron-overlay-closed', spy);
           MockInteractions.tap(document.body);
-          setTimeout(function() {
+          setTimeout(() => {
             assert.isFalse(spy.called, 'iron-overlay-closed should not fire');
             done();
           }, 10);
         });
       });
 
-      test('no-cancel-on-esc-key property', function(done) {
+      test('no-cancel-on-esc-key property', done => {
         overlay.noCancelOnEscKey = true;
-        runAfterOpen(overlay, function() {
+        runAfterOpen(overlay, () => {
           const spy = sinon.stub();
           overlay.addEventListener('iron-overlay-closed', spy);
           MockInteractions.pressAndReleaseKeyOn(document, 27);
-          setTimeout(function() {
+          setTimeout(() => {
             assert.isFalse(spy.called, 'iron-overlay-cancel should not fire');
             done();
           }, 10);
@@ -285,19 +285,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     });
 
-    suite('opened overlay', function() {
+    suite('opened overlay', () => {
 
-      setup(function() {
+      setup(() => {
         overlay = fixture('opened');
       });
 
-      test('overlay open by default', function() {
+      test('overlay open by default', () => {
         assert.isTrue(overlay.opened, 'overlay starts opened');
         assert.isOk(overlay.renderer, 'overlay has a renderer');
       });
 
-      test('overlay positioned & sized properly', function(done) {
-        setTimeout(function() {
+      test('overlay positioned & sized properly', done => {
+        setTimeout(() => {
           const rect = overlay.renderer.$.overlay.getBoundingClientRect();
           assert.closeTo(rect.left, (window.innerWidth - rect.width) / 2, 1, 'centered horizontally');
           assert.closeTo(rect.top, (window.innerHeight - rect.height) / 2, 1, 'centered vertically');
@@ -319,25 +319,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return waitNextEvent(overlay, 'iron-overlay-closed');
     };
 
-    suite('attach/detach', function() {
+    suite('attach/detach', () => {
 
-      setup(function() {
+      setup(() => {
         overlay = fixture('basic');
       });
 
-      test('detached overlay does not create the renderer', function(done) {
+      test('detached overlay does not create the renderer', done => {
         const spy = sinon.stub();
         overlay.addEventListener('iron-overlay-opened', spy);
         overlay.parentNode.removeChild(overlay);
         overlay.opened = true;
         assert.isNotOk(overlay.renderer, 'renderer not initialized');
-        setTimeout(function() {
+        setTimeout(() => {
           assert.isFalse(spy.called, 'iron-overlay-opened should not fire');
           done();
         }, 100);
       });
 
-      test('removing overlay from the DOM closes it', function(done) {
+      test('removing overlay from the DOM closes it', done => {
         openPromise(overlay)
           .then(() => {
             overlay.parentNode.removeChild(overlay);
@@ -348,7 +348,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           .catch(done);
       });
 
-      test('reparent overlay', function(done) {
+      test('reparent overlay', done => {
         const parent = overlay.parentNode;
         openPromise(overlay)
           .then(() => {
@@ -370,19 +370,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     focusSuiteForFixture('scoped');
 
-    suite('multiple overlays', function() {
+    suite('multiple overlays', () => {
       let overlay1,
         overlay2;
 
-      setup(function() {
+      setup(() => {
         const f = fixture('multiple');
         overlay1 = f[0];
         overlay2 = f[1];
       });
 
-      test('ESC closes only the top overlay', function(done) {
-        runAfterOpen(overlay1, function() {
-          runAfterOpen(overlay2, function() {
+      test('ESC closes only the top overlay', done => {
+        runAfterOpen(overlay1, () => {
+          runAfterOpen(overlay2, () => {
             MockInteractions.pressAndReleaseKeyOn(document, 27);
             assert.isFalse(overlay2.opened, 'overlay2 was closed');
             assert.isTrue(overlay1.opened, 'overlay1 is still opened');
@@ -391,10 +391,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('ESC event handling is delegated to interested overlay', function(done) {
+      test('ESC event handling is delegated to interested overlay', done => {
         overlay2.noCancelOnEscKey = true;
-        runAfterOpen(overlay1, function() {
-          runAfterOpen(overlay2, function() {
+        runAfterOpen(overlay1, () => {
+          runAfterOpen(overlay2, () => {
             MockInteractions.pressAndReleaseKeyOn(document, 27);
             assert.isTrue(overlay2.opened, 'overlay2 still opened');
             assert.isFalse(overlay1.opened, 'overlay1 closed');
@@ -403,10 +403,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('click event handling is delegated to interested overlay', function(done) {
+      test('click event handling is delegated to interested overlay', done => {
         overlay2.noCancelOnOutsideClick = true;
-        runAfterOpen(overlay1, function() {
-          runAfterOpen(overlay2, function() {
+        runAfterOpen(overlay1, () => {
+          runAfterOpen(overlay2, () => {
             MockInteractions.tap(document.body);
             assert.isTrue(overlay2.opened, 'overlay2 still opened');
             assert.isFalse(overlay1.opened, 'overlay1 closed');
@@ -415,10 +415,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('button click event handling closes only top overlay', function(done) {
+      test('button click event handling closes only top overlay', done => {
         overlay2.noCancelOnOutsideClick = true;
-        runAfterOpen(overlay1, function() {
-          runAfterOpen(overlay2, function() {
+        runAfterOpen(overlay1, () => {
+          runAfterOpen(overlay2, () => {
             const button = overlay2.contentHost.querySelector('button');
             button.addEventListener('click', () => overlay2.opened = false);
             MockInteractions.tap(button);
@@ -429,7 +429,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('close an overlay in proximity to another overlay', function(done) {
+      test('close an overlay in proximity to another overlay', done => {
         // Open and close a separate overlay.
         overlay1.opened = true;
         overlay1.opened = false;
@@ -438,25 +438,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overlay2.opened = true;
 
         // Immediately close the first overlay. Wait for infinite recursion, otherwise we win.
-        runAfterClose(overlay2, function() {
+        runAfterClose(overlay2, () => {
           done();
         })
       });
 
     });
 
-    suite('scoped overlay', function() {
+    suite('scoped overlay', () => {
 
-      setup(function() {
+      setup(() => {
         overlay = fixture('scoped');
         overlay.opened = true;
       });
 
-      test('can query content', function() {
+      test('can query content', () => {
         assert.isOk(overlay.contentHost.querySelector('button'));
       });
 
-      test('can listen to non-composed events content', function() {
+      test('can listen to non-composed events content', () => {
         const spy = sinon.spy();
         overlay.contentHost.addEventListener('some-event', spy);
         overlay.contentHost.querySelector('button').dispatchEvent(new CustomEvent('some-event', {
@@ -466,7 +466,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(spy.callCount, 1);
       });
 
-      test('styles are scoped', function() {
+      test('styles are scoped', () => {
         // Force distribution & styling.
         window.ShadyDOM && ShadyDOM.flush();
         assert.notEqual(
@@ -500,14 +500,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     function focusSuiteForFixture(fixtureName) {
-      return suite(fixtureName + ' overlay focus handling', function() {
+      return suite(fixtureName + ' overlay focus handling', () => {
 
-        setup(function() {
+        setup(() => {
           overlay = fixture(fixtureName);
         });
 
-        test('node with autofocus is focused', function(done) {
-          runAfterOpen(overlay, function() {
+        test('node with autofocus is focused', done => {
+          runAfterOpen(overlay, () => {
             const autofocused = overlay.contentHost.querySelector('[autofocus]');
             assert.equal(getDeepActiveElement(), autofocused,
               '<button autofocus> is focused');
@@ -515,9 +515,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('no-auto-focus will not focus node with autofocus', function(done) {
+        test('no-auto-focus will not focus node with autofocus', done => {
           overlay.noAutoFocus = true;
-          runAfterOpen(overlay, function() {
+          runAfterOpen(overlay, () => {
             const autofocused = overlay.contentHost.querySelector('[autofocus]');
             assert.notEqual(getDeepActiveElement(), autofocused,
               '<button autofocus> not focused after opened');
@@ -529,24 +529,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             '<button autofocus> not immediately focused');
         });
 
-        suite('restore focus', function() {
-          setup(function() {
+        suite('restore focus', () => {
+          setup(() => {
             button0.focus();
           });
 
-          test('restores focus to previous focusable', function(done) {
-            runAfterOpen(overlay, function() {
-              runAfterClose(overlay, function() {
+          test('restores focus to previous focusable', done => {
+            runAfterOpen(overlay, () => {
+              runAfterClose(overlay, () => {
                 assert.equal(getDeepActiveElement(), button0, 'focus returned to button');
                 done();
               });
             });
           });
 
-          test('avoids restoring focus if focus changed', function(done) {
-            runAfterOpen(overlay, function() {
+          test('avoids restoring focus if focus changed', done => {
+            runAfterOpen(overlay, () => {
               button1.focus();
-              runAfterClose(overlay, function() {
+              runAfterClose(overlay, () => {
                 assert.equal(getDeepActiveElement(), button1, 'focus was not modified');
                 done();
               });

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -437,6 +437,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Open so content is created
         overlay1.opened = true;
         overlay2.opened = true;
+        // Force distribution & styling.
+        window.ShadyDOM && ShadyDOM.flush();
         var btn1 = overlay1._contentHost.querySelector('button');
         var btn2 = overlay2._contentHost.querySelector('button');
         assert.notEqual(getComputedStyle(btn1).color, 'rgb(255, 0, 0)', 'overlay1 btn color ok');

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -329,7 +329,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('tap event handling is delegated to interested overlay', function(done) {
+      test('click event handling is delegated to interested overlay', function(done) {
         overlay2.noCancelOnOutsideClick = true;
         runAfterOpen(overlay1, function() {
           runAfterOpen(overlay2, function() {
@@ -341,12 +341,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('button tap event handling closes only top overlay', function(done) {
+      test('button click event handling closes only top overlay', function(done) {
         overlay2.noCancelOnOutsideClick = true;
         runAfterOpen(overlay1, function() {
           runAfterOpen(overlay2, function() {
             const button = overlay2.contentHost.querySelector('button');
-            button.addEventListener('tap', () => overlay2.opened = false);
+            button.addEventListener('click', () => overlay2.opened = false);
             MockInteractions.tap(button);
             assert.isFalse(overlay2.opened, 'overlay2 closed');
             assert.isTrue(overlay1.opened, 'overlay1 still opened');

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -58,17 +58,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <iron-overlay class="overlay-1">
         <template>
           Test overlay 1
+          <button>Click</button>
         </template>
       </iron-overlay>
       <iron-overlay class="overlay-2">
         <template>
+          <style>
+            button {
+              color: red;
+            }
+          </style>
           Test overlay 2
           <button>Click</button>
-        </template>
-      </iron-overlay>
-      <iron-overlay class="overlay-3">
-        <template>
-          Other overlay 3
         </template>
       </iron-overlay>
     </template>
@@ -302,7 +303,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('node with autofocus is focused', function(done) {
         runAfterOpen(overlay, function() {
-          assert.isTrue(overlay.renderer.contains(document.activeElement), '<button autofocus> is focused');
+          assert.isTrue(overlay._contentHost.contains(document.activeElement), '<button autofocus> is focused');
           done();
         });
       });
@@ -310,12 +311,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('no-auto-focus will not focus node with autofocus', function(done) {
         overlay.noAutoFocus = true;
         runAfterOpen(overlay, function() {
-          assert.isFalse(overlay.renderer.contains(document.activeElement), document.activeElement,
+          assert.isFalse(overlay._contentHost.contains(document.activeElement), document.activeElement,
             '<button autofocus> not focused after opened');
           done();
         });
         // In Safari the element with autofocus will immediately receive focus when displayed for the first time http://jsbin.com/woroci/2/ Ensure this is not the case for overlay.
-        assert.isFalse(overlay.renderer.contains(document.activeElement),
+        assert.isFalse(overlay._contentHost.contains(document.activeElement),
           '<button autofocus> not immediately focused');
       });
 
@@ -408,7 +409,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overlay2.noCancelOnOutsideClick = true;
         runAfterOpen(overlay1, function() {
           runAfterOpen(overlay2, function() {
-            const button = overlay2.renderer.querySelector('button');
+            const button = overlay2._contentHost.querySelector('button');
             button.addEventListener('tap', overlay2.close.bind(overlay2));
             MockInteractions.tap(button);
             assert.isFalse(overlay2.opened, 'overlay2 closed');
@@ -430,6 +431,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         runAfterClose(overlay2, function() {
           done();
         })
+      });
+
+      test('styles are scoped', function() {
+        // Open so content is created
+        overlay1.opened = true;
+        overlay2.opened = true;
+        var btn1 = overlay1._contentHost.querySelector('button');
+        var btn2 = overlay2._contentHost.querySelector('button');
+        assert.notEqual(getComputedStyle(btn1).color, 'rgb(255, 0, 0)', 'overlay1 btn color ok');
+        assert.equal(getComputedStyle(btn2).color, 'rgb(255, 0, 0)', 'overlay2 btn color ok');
       });
 
     });

--- a/test/iron-overlay.html
+++ b/test/iron-overlay.html
@@ -322,7 +322,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('no-auto-focus will not focus node with autofocus', function(done) {
         overlay.noAutoFocus = true;
         runAfterOpen(overlay, function() {
-          assert.isFalse(overlay.contentHost.contains(document.activeElement), document.activeElement,
+          assert.isFalse(overlay.contentHost.contains(document.activeElement),
             '<button autofocus> not focused after opened');
           done();
         });
@@ -330,16 +330,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isFalse(overlay.contentHost.contains(document.activeElement),
           '<button autofocus> not immediately focused');
       });
-
-      test('with-backdrop traps the focus within the overlay', function() {
-        if (document.$blockingElements) {
-          overlay.withBackdrop = true;
-          assert.isFalse(document.$blockingElements.has(overlay), 'not a blocking element when closed');
-          overlay.opened = true;
-          assert.isTrue(document.$blockingElements.has(overlay), 'is a blocking element when opened');
-        }
-      });
-
 
       suite('restore focus', function() {
         let buttons;


### PR DESCRIPTION
Fixes #2
~~If we find a `<style>` in the content template,~~ we scope it by creating an intermediate element and host content in its shadowRoot.
Added new property `contentHost` to allow querySelectors & adding event listeners on the right host.

- [x] update README.md
- [x] update demo
- [x] add tests

~~Tests failing because of https://github.com/webcomponents/shadydom/issues/130~~